### PR TITLE
회원 상태 추가, 상태에 따른 로그인 로직 변경

### DIFF
--- a/AccountApi/src/main/java/com/nhnacademy/edu/minidooray/AccountApi/domain/User.java
+++ b/AccountApi/src/main/java/com/nhnacademy/edu/minidooray/AccountApi/domain/User.java
@@ -26,6 +26,8 @@ public class User {
 
     private String password;
 
+    private String status;
+
     @Column(name = "last_login")
     private LocalDate lastLogin;
 }

--- a/AccountApi/src/main/java/com/nhnacademy/edu/minidooray/AccountApi/repository/UserRepository.java
+++ b/AccountApi/src/main/java/com/nhnacademy/edu/minidooray/AccountApi/repository/UserRepository.java
@@ -2,10 +2,23 @@ package com.nhnacademy.edu.minidooray.AccountApi.repository;
 
 
 import com.nhnacademy.edu.minidooray.AccountApi.domain.User;
+import java.time.LocalDate;
+import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
 
 public interface UserRepository extends JpaRepository<User, String> {
-    Optional<User> findByIdAndPassword(String id, String password);
+    Optional<User> findByIdAndPasswordAndStatus(String id, String password, String status);
 
+    @Modifying
+    @Query("UPDATE User s SET s.lastLogin = ?2 WHERE s.id = ?1")
+    void updateLastLoginDate(String id, LocalDate localDate);
+
+    @Modifying
+    @Query("UPDATE User s SET s.status = ?2 WHERE s.id = ?1")
+    void updateUserStatus(String id, String status);
+
+    List<User> findByLastLoginBeforeAndStatus(LocalDate twoYearsAgo, String status);
 }

--- a/AccountApi/src/main/java/com/nhnacademy/edu/minidooray/AccountApi/service/UserService.java
+++ b/AccountApi/src/main/java/com/nhnacademy/edu/minidooray/AccountApi/service/UserService.java
@@ -10,4 +10,7 @@ public interface UserService {
     void createUser(CreateUserRequest createUserRequest);
 
     void deleteUser(String id);
+
+    void updateInactiveUserStatus();
+
 }


### PR DESCRIPTION
- 회원 상태
- 로그인시 상태가 "가입"인 유저만 탐색
- 마지막 로그인 2년 이후 상태가 "휴면"으로 전환
- 탈퇴시 상태가 "탈퇴"로 전환